### PR TITLE
Giving Woocommerce styles custom variables

### DIFF
--- a/woocommerce/css/woocommerce-style.css
+++ b/woocommerce/css/woocommerce-style.css
@@ -33,11 +33,11 @@
 
 .cart-loader {
     top: 56px;
-    z-index: 1
+    z-index: 1;
 }
 
 .cart-loader .loader-icon {
-    margin-top: -56px
+    margin-top: -56px;
 }
 
 
@@ -111,45 +111,45 @@ form.cart .blockUI.blockOverlay {
 --------------------------------------------------------------*/
 
 .woocommerce .woocommerce-result-count, .woocommerce-page .woocommerce-result-count {
-    float: none
+    float: none;
 }
 
 .woocommerce .woocommerce-ordering, .woocommerce-page .woocommerce-ordering {
-    float: none
+    float: none;
 }
 
 .woocommerce .woocommerce-ordering {
-    margin: 0
+    margin: 0;
 }
 
 .woocommerce-account .woocommerce-MyAccount-navigation {
     float: none;
-    width: 100%
+    width: 100%;
 }
 
 .woocommerce-account .woocommerce-MyAccount-content {
     float: none;
-    width: 100%
+    width: 100%;
 }
 
 .woocommerce .woocommerce-customer-details address {
     border: 0;
     width: 100%;
-    padding: 0
+    padding: 0;
 }
 
 .woocommerce form .form-row {
     padding: 0;
-    margin: 0 0 1rem
+    margin: 0 0 1rem;
 }
 
 .woocommerce form .form-row label {
-    line-height: 1.5
+    line-height: 1.5;
 }
 
 .woocommerce .cart-collaterals .cart_totals, .woocommerce-page .cart-collaterals .cart_totals {
     float: none;
-    width: 100%
+    width: 100%;
 }
 
 .group_table .add-to-cart-container {
@@ -164,7 +164,7 @@ form.cart .blockUI.blockOverlay {
 
 .products .card .star-rating, .card .star-rating {
     float: none;
-    margin: 1rem auto
+    margin: 1rem auto;
 }
 
 a.woocommerce-LoopProduct-link.woocommerce-loop-product__link, a.woocommerce-LoopProduct-link.woocommerce-loop-product__link:hover {
@@ -177,60 +177,60 @@ a.woocommerce-LoopProduct-link.woocommerce-loop-product__link, a.woocommerce-Loo
 }
 
 .woocommerce-input-wrapper {
-    width: 100%
+    width: 100%;
 }
 
 span.badge.bg-danger.sale {
     position: absolute;
     left: 1rem;
-    top: 1rem
+    top: 1rem;
 }
 
 span.badge.bg-danger.sale, span.badge.bg-danger.sale-product {
-    font-size: 1.25rem
+    font-size: 1.25rem;
 }
 
 .sale-product {
     position: absolute;
     left: 1rem;
     top: 1rem;
-    z-index: 1
+    z-index: 1;
 }
 
 .card.h-100.d-flex.product a:hover {
-    text-decoration: none
+    text-decoration: none;
 }
 
 .woocommerce .col2-set .col-1, .woocommerce-page .col2-set .col-1 {
     float: none;
-    width: 100%
+    width: 100%;
 }
 
 .woocommerce .col2-set .col-2, .woocommerce-page .col2-set .col-2 {
     float: none;
-    width: 100%
+    width: 100%;
 }
 
 @media (max-width:768px) {
     .refresh-cart {
-        width: 100%
+        width: 100%;
     }
 }
 
 .woocommerce table.shop_table td {
-    border-top: 1px solid
+    border-top: 1px solid;
 }
 
 #add_payment_method .cart-collaterals .cart_totals tr td, #add_payment_method .cart-collaterals .cart_totals tr th, .woocommerce-cart .cart-collaterals .cart_totals tr td, .woocommerce-cart .cart-collaterals .cart_totals tr th, .woocommerce-checkout .cart-collaterals .cart_totals tr td, .woocommerce-checkout .cart-collaterals .cart_totals tr th {
-    border-top: 1px solid
+    border-top: 1px solid;
 }
 
 .woocommerce-price-suffix {
-    display: block
+    display: block;
 }
 
 ins {
-    text-decoration: none
+    text-decoration: none;
 }
 
 #add_payment_method #payment div.payment_box, .woocommerce-cart #payment div.payment_box, .woocommerce-checkout #payment div.payment_box {
@@ -252,11 +252,11 @@ ins {
 }
 
 .woocommerce div.product .woocommerce-tabs ul.tabs li {
-    border-radius: .25rem .25rem 0 0
+    border-radius: .25rem .25rem 0 0;
 }
 
 button.single_add_to_cart_button.btn.btn-primary.disabled.wc-variation-selection-needed:hover {
-    cursor: not-allowed
+    cursor: not-allowed;
 }
 
 .woocommerce div.product form.cart .variations select {
@@ -264,7 +264,7 @@ button.single_add_to_cart_button.btn.btn-primary.disabled.wc-variation-selection
 }
 
 label.custom-control-label {
-    line-height: 1.5 !important
+    line-height: 1.5 !important;
 }
 
 #payment label.form-check-label img {
@@ -277,7 +277,7 @@ label.custom-control-label {
     padding: 0;
     margin: 0;
     text-align: left;
-    border-radius: 0
+    border-radius: 0;
 }
 
 .woocommerce .blockUI.blockOverlay:before, .woocommerce .loader:before, #offcanvas-cart .blockUI.blockOverlay:before, #offcanvas-cart .loader:before {
@@ -306,44 +306,44 @@ label.custom-control-label {
     border-right-color: transparent;
     border-radius: 50%;
     -webkit-animation: spinner-border .75s linear infinite;
-    animation: spinner-border .75s linear infinite
+    animation: spinner-border .75s linear infinite;
 }
 
 .woocommerce-variation.single_variation {
-    margin-bottom: 2rem
+    margin-bottom: 2rem;
 }
 
 .woocommerce .woocommerce-terms-and-conditions, .woocommerce-page .woocommerce-terms-and-conditions {
     margin-bottom: 1rem;
-    padding: 1.25rem
+    padding: 1.25rem;
 }
 
 .woocommerce-terms-and-conditions {
     border: none;
     box-shadow: none;
-    border-radius: .25rem
+    border-radius: .25rem;
 }
 
 ul.tabs.wc-tabs {
     overflow-x: auto !important;
-    white-space: nowrap
+    white-space: nowrap;
 }
 
 .reviews_tab {
-    margin-right: 0
+    margin-right: 0;
 }
 
 span.password-input {
-    width: 100%
+    width: 100%;
 }
 
 #order_review .legal label {
-    display: block !important
+    display: block !important;
 }
 
 .wc-gzd-product-name-left img {
     border-radius: .25rem;
-    border: 1px solid transparent
+    border: 1px solid transparent;
 }
 
 
@@ -355,32 +355,32 @@ span.password-input {
     font-weight: 400;
     border-radius: .25rem;
     border: 1px solid;
-    transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out
+    transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 }
 
 .place-order div {
-    width: 100%
+    width: 100%;
 }
 
 button#place_order {
     width: 100%;
-    margin-top: 1rem
+    margin-top: 1rem;
 }
 
 .woocommerce table.shop_attributes td {
-    font-style: normal
+    font-style: normal;
 }
 
 .woocommerce table.shop_attributes td {
-    border-bottom: 1px solid
+    border-bottom: 1px solid;
 }
 
 .woocommerce table.shop_attributes th {
-    border-bottom: 1px solid
+    border-bottom: 1px solid;
 }
 
 .woocommerce table.shop_attributes {
-    border-top: 1px solid
+    border-top: 1px solid;
 }
 
 .product_meta .sku_wrapper::after, .product_meta .posted_in::after {

--- a/woocommerce/css/woocommerce-style.css
+++ b/woocommerce/css/woocommerce-style.css
@@ -541,7 +541,7 @@ ul.tabs.wc-tabs {
 }
 
 .woocommerce div.product p.price, .woocommerce div.product span.price, .card .price {
-    color: var(--bs-gray);
+    color: var(--bscore-wc-price, var(--bs-gray));
 }
 
 .woocommerce div.product p.price del, .woocommerce div.product span.price del, del, .card del .woocommerce-Price-amount.amount, .card del .woocommerce-Price-amount.amount {
@@ -549,19 +549,19 @@ ul.tabs.wc-tabs {
 }
 
 .woocommerce div.product p.price ins, .woocommerce div.product span.price ins, ins {
-    color: var(--bs-danger);
+    color: var(--bscore-wc-price-sale, var(--bs-danger));
 }
 
 .woocommerce form .form-row .required, .woocommerce form .form-row.woocommerce-invalid label {
-    color: var(--bs-danger);
+    color: var(--bscore-wc-form-invalid, var(--bs-danger));
 }
 
 .woocommerce form .form-row.woocommerce-invalid .select2-container, .woocommerce form .form-row.woocommerce-invalid input.input-text, .woocommerce form .form-row.woocommerce-invalid select {
-    border-color: var(--bs-danger);
+    border-color: var(--bscore-wc-form-invalid, var(--bs-danger));
 }
 
 .woocommerce form .form-row.woocommerce-validated .select2-container, .woocommerce form .form-row.woocommerce-validated input.input-text, .woocommerce form .form-row.woocommerce-validated select {
-    border-color: var(--bs-success);
+    border-color: var(--bscore-wc-form-valid, var(--bs-success));
 }
 
 .woocommerce div.product p.price del, .woocommerce div.product span.price del {
@@ -574,70 +574,70 @@ ul.tabs.wc-tabs {
 
 @media (max-width:768px) {
     .woocommerce table.shop_table_responsive tr:nth-child(2n) td, .woocommerce-page table.shop_table_responsive tr:nth-child(2n) td {
-        background-color: var(--bs-light);
+        background-color: var(--bscore-shop-table-responsive, var(--bs-light));
     }
 }
 
 .woocommerce table.shop_table, .woocommerce table.shop_table td {
-    border-color: var(--bs-gray-300);
+    border-color: var(--bscore-wc-shop-table-border, var(--bs-gray-300));
 }
 
 #add_payment_method .cart-collaterals .cart_totals tr td, #add_payment_method .cart-collaterals .cart_totals tr th, .woocommerce-cart .cart-collaterals .cart_totals tr td, .woocommerce-cart .cart-collaterals .cart_totals tr th, .woocommerce-checkout .cart-collaterals .cart_totals tr td, .woocommerce-checkout .cart-collaterals .cart_totals tr th {
-    border-color: var(--bs-gray-300);
+    border-color: var(--bscore-wc-cart-totals-divider, var(--bs-gray-300));
 }
 
 #add_payment_method #payment div.payment_box, .woocommerce-cart #payment div.payment_box, .woocommerce-checkout #payment div.payment_box {
-    background-color: var(--bs-light);
-    color: currentColor
+    background-color: var(--bscore-wc-payment-box, var(--bs-light));
+    color: currentColor;
 }
 
 #add_payment_method #payment div.payment_box::before, .woocommerce-cart #payment div.payment_box::before, .woocommerce-checkout #payment div.payment_box::before {
     content: "";
     display: block;
-    border: 1em solid var(--bs-light);
+    border: 1em solid var(--bscore-wc-payment-box, var(--bs-light));
     border-right-color: transparent;
     border-left-color: transparent;
     border-top-color: transparent;
     position: absolute;
     top: -.75em;
     left: 0;
-    margin: -1em 0 0 2em
+    margin: -1em 0 0 2em;
 }
 
 .woocommerce div.product .woocommerce-tabs ul.tabs li {
-    border: 1px solid var(--bs-gray-300);
-    background-color: var(--bs-light)
+    border: 1px solid var(--bscore-wc-tabs-border, var(--bs-gray-300));
+    background-color: var(--bscore-wc-tabs-bg, var(--bs-light));
 }
 
 .woocommerce div.product .woocommerce-tabs ul.tabs::before {
-    border-bottom: 1px solid var(--bs-gray-300)
+    border-bottom: 1px solid var(--bscore-wc-tabs-border, var(--bs-gray-300));
 }
 
 .woocommerce-terms-and-conditions {
-    background: var(--bs-light)
+    background: var(--bscore-terms, var(--bs-light));
 }
 
 .woocommerce div.product .woocommerce-tabs ul.tabs li a {
-    color: var(--bs-primary)
+    color: var(--bscore-wc-tabs-a, var(--bs-primary));
 }
 
 .woocommerce-checkout .shop_table {
-    background-color: var(--bs-white) !important;
+    background-color: var(--bscore-wc-shop-table-bg, var(--bs-white)) !important;
 }
 
 .wc-gzd-product-name-left img {
-    border-color: var(--bs-gray-300)
+    border-color: var(--bscore-wc-product-name-img, var(--bs-gray-300));
 }
 
 .woocommerce #respond input#submit, .woocommerce a.button, .woocommerce button.button, .woocommerce input.button {
-    color: var(--bs-primary);
+    color: var(--bscore-wc-button-color ,var(--bs-primary));
     background-color: transparent;
-    border-color: var(--bs-primary);
+    border-color: var(--bscore-wc-button-border, var(--bs-primary));
 }
 
 .woocommerce #respond input#submit:hover, .woocommerce a.button:hover, .woocommerce button.button:hover, .woocommerce input.button:hover {
-    color: var(--bs-white);
-    background-color: var(--bs-primary);
+    color: var(--bscore-wc-button-color-hover, var(--bs-white));
+    background-color: var(--bscore-wc-button-border-hover, var(--bs-primary));
 }
 
 .woocommerce div.product .stock {
@@ -645,7 +645,7 @@ ul.tabs.wc-tabs {
 }
 
 .woocommerce div.product .out-of-stock {
-    color: var(--bs-danger);
+    color: var(--bscore-wc-out-of-stock, var(--bs-danger));
 }
 
 /* Gallery Overlay */
@@ -655,28 +655,28 @@ ul.tabs.wc-tabs {
 
 
 .woocommerce .blockUI.blockOverlay, .woocommerce .loader, #offcanvas-cart .blockUI.blockOverlay, #offcanvas-cart .loader {
-    background-color: var(--bs-white) !important;
+    background-color: var(--bscore-wc-loader-bg, var(--bs-white)) !important;
     opacity: 1 !important;
 }
 
 .woocommerce .blockUI.blockOverlay:before, .woocommerce .loader:before, #offcanvas-cart .blockUI.blockOverlay:before, #offcanvas-cart .loader:before {
-    color: var(--bs-primary);
+    color: var(--bscore-wc-loader-color, var(--bs-primary));
 }
 
 .woocommerce table.shop_attributes tr:nth-child(even) td, .woocommerce table.shop_attributes tr:nth-child(even) th {
-    background: var(--bs-light);
+    background: var(--bscore-wc-attributes-tr, var(--bs-light));
 }
 
 .woocommerce table.shop_attributes td {
-    border-color: var(--bs-gray-300);
+    border-color: var(--bscore-wc-attributes-td, var(--bs-gray-300));
 }
 
 .woocommerce table.shop_attributes th {
-    border-color: var(--bs-gray-300);
+    border-color: var(--bscore-wc-attributes-th, var(--bs-gray-300));
 }
 
 .woocommerce table.shop_attributes {
-    border-color: var(--bs-gray-300);
+    border-color: var(--bscore-wc-attributes, var(--bs-gray-300));
 }
 
 .pswp__ui--fit .pswp__caption, .pswp__ui--fit .pswp__top-bar {
@@ -684,11 +684,11 @@ ul.tabs.wc-tabs {
 }
 
 .woocommerce .widget_price_filter .price_slider_wrapper .ui-widget-content {
-    background-color: var(--bs-dark);
+    background-color: var(--bscore-wc-price-slider-bg, var(--bs-dark));
 }
 
 .woocommerce .widget_price_filter .ui-slider .ui-slider-handle, .woocommerce .widget_price_filter .ui-slider .ui-slider-range {
-    background-color: var(--bs-primary);
+    background-color: var(--bscore-wc-price-slider, var(--bs-primary));
 }
 
 .woocommerce-info::before, .woocommerce-message::before, .restore-item, .restore-item:hover {


### PR DESCRIPTION
As per issue #12, we decided that it's a good idea to give Woocommerce classes that call a Bootstap variable a custom bootScore variable that isn't set by default. That way you can easily override specific colors, and don't have to worry about updates to the Woocommerce files.